### PR TITLE
Implement queueing capabilities for cars by observing distance of front car, and fix intersection adjacent light state issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -119,13 +119,15 @@ class Car:
             self.cars_in_the_same_edge = tm.get_cars_in_edge(self.origin_node, self.next_destination_node)
 
             #exclude the car in the dictionary since we don't need to be checking its own position
+
+            #if transformed into a queue, just get the items before the index of the current car
+
             self.cars_in_the_same_edge = {k:v for k,v in self.cars_in_the_same_edge.items() if k != self.index}
             # print(f"{self.cars_in_the_same_edge.keys()} called by {self.index}")
 
             #get distance of other cars
             distance_to_other_cars = [math.dist(adjacent_car.get_coords(), self.get_coords()) for index, adjacent_car in self.cars_in_the_same_edge.items()]
             print(distance_to_other_cars)
-
 
             step = min(self.speed, distance)
             self.pos_x += (dx / distance) * step

--- a/main.py
+++ b/main.py
@@ -293,18 +293,20 @@ class TrafficManager():
         for n in self.G:
             # print(f"G Degree of {n}: {self.G.degree[n]}")
             # Apply intersection light states between nodes
-            if self.G.degree[n] > 2: #check if node has more than 2 neighbors then apply intersection light states
+            if self.G.in_degree[n] > 2: #check if node has more than 2 neighbors then apply intersection light states
                 neighbor_nodes = list(self.G.neighbors(n))
                 self.intersection_states[n] = {}
                 # This function is used to generate a dictionary of light states between nodes and neighbors
                 for index, neighbor in enumerate(neighbor_nodes): #needed to enumerate so I can use module to alternate values
                     color_state = "green"
-                    if index % 2 == 0: #alternate light states between nodes
+                    if index % 3 == 0: #alternate light states between nodes
                         color_state = "red"
                     self.intersection_states[n][neighbor] = {
                         "color": color_state,
                         "timer": self.default_intersection_time
                     }
+
+                    print(f"Setting {n}, Neighbor {neighbor} to {color_state}")
 
         # Draw the intersection of all nodes in the intersection_nodes.
         for index, pos in self.intersection_nodes.items():

--- a/main.py
+++ b/main.py
@@ -143,12 +143,15 @@ class TrafficManager():
     def manage_car_from_edge(self, car_index: int, origin: int, destination: int, how: str):
         orientation = None
 
+        if any(((origin, destination) in self.edges.keys(), (destination, origin) in self.edges.keys())):
+            orientation = (origin, destination) if (origin, destination) in self.edges.keys() else (destination, origin)
+
         #Example tuple (5, 6) Where 5 is how it is placed in the edges list and 6 is the immediate destination
-        if (origin, destination) in self.edges.keys(): 
-            orientation = (origin, destination)
-        #if (6, 5)
-        elif (destination, origin) in self.edges.keys():
-            orientation = (destination, origin)
+        # if (origin, destination) in self.edges.keys(): 
+        #     orientation = (origin, destination)
+        # #if (6, 5)
+        # elif (destination, origin) in self.edges.keys():
+        #     orientation = (destination, origin)
 
         if orientation:
             if how == "add":
@@ -160,8 +163,17 @@ class TrafficManager():
             else: raise Exception("Invalid 'how' value, must be 'add' or 'remove'")
         else:
             raise KeyError(f"Cannot find the edge {(origin, destination)} or {(destination,origin)}")
-    def __draw_intersection__(self, x, y, index=None, offset=5, color="blue"):
+        
+    def get_cars_in_edge(self, origin, destination):
+        orientation = None
+        cars_in_edge = None
+        if any(((origin, destination) in self.edges.keys(), (destination, origin) in self.edges.keys())):
+            orientation = (origin, destination) if (origin, destination) in self.edges.keys() else (destination, origin)
+            cars_in_edge = self.edges[orientation]['cars_occupied']
 
+        return cars_in_edge
+
+    def __draw_intersection__(self, x, y, index=None, offset=5, color="blue"):
         """
         Now drawing the road network using the graph
         """
@@ -273,7 +285,10 @@ class Car:
             self.pos_y += (dy / distance) * step
             self._move_to(self.pos_x, self.pos_y)
 
+        # Get the cars that are in the same edge as the current car
+
         if distance > self.light_observation_distance:
+            # cars_in_same_edge = tm.get_cars_in_edge(self.origin_node, self.next_destination_node)
             __move()
 
         elif distance > 0:

--- a/main.py
+++ b/main.py
@@ -152,23 +152,17 @@ class TrafficManager():
     def manage_car_from_edge(self, car_object: any, origin: int, destination: int, how: str):
         orientation = None
 
+        # Example tuple (1, 2) Where 1 is how it is placed in the edges list originally and 2 is the immediate destination
+        # And a instance where an agent is going from (2, 1) we still want to recognize this as (1, 2) as it was defined in the edges list
+        # This is what this function does by switching its orientation if this instance happens to be happening
         if any(((origin, destination) in self.edges.keys(), (destination, origin) in self.edges.keys())):
             orientation = (origin, destination) if (origin, destination) in self.edges.keys() else (destination, origin)
 
-        #Example tuple (5, 6) Where 5 is how it is placed in the edges list and 6 is the immediate destination
-        # if (origin, destination) in self.edges.keys(): 
-        #     orientation = (origin, destination)
-        # #if (6, 5)
-        # elif (destination, origin) in self.edges.keys():
-        #     orientation = (destination, origin)
-
         if orientation:
             if how == "add":
-                # self.edges[orientation]['cars_occupied'].append(car_index)
                 self.edges[orientation]['cars_occupied'][car_object.index] = car_object
                 print(f"Added {car_object.index} to {orientation}")
             elif how == "remove":
-                # self.edges[orientation]['cars_occupied'].remove(car_index)
                 removed_car = self.edges[orientation]['cars_occupied'].pop(car_object.index, None)
                 if not removed_car:
                     print("Removed nothing, check what the issue is. Not harmful as of this writing")

--- a/main.py
+++ b/main.py
@@ -127,7 +127,39 @@ class TrafficManager():
         for edge in self.edges:
             self.__draw_line_from_edge__(*edge)
             
+    # def add_car_to_edge(self, car_index, origin, destination):
+    #     #check the orientation of origin,destination in the tuple
+    #     orientation1 = (origin, destination)
+    #     orientation2 = (destination, origin)
+    #     if orientation1 in self.edges.keys() or orientation2 in self.edges.keys():
+    #         self.edges[orientation1]['cars_occupied'].append(car_index)
 
+    # def remove_car_from_edge(self, car_index, origin, destination):
+    #     orientation1 = (origin, destination)
+    #     orientation2 = (destination, origin)
+    #     if orientation1 in self.edges.keys() or orientation2 in self.edges.keys():
+    #         self.edges[orientation1]['cars_occupied'].remove(car_index)
+
+    def manage_car_from_edge(self, car_index: int, origin: int, destination: int, how: str):
+        orientation = None
+
+        #Example tuple (5, 6) Where 5 is how it is placed in the edges list and 6 is the immediate destination
+        if (origin, destination) in self.edges.keys(): 
+            orientation = (origin, destination)
+        #if (6, 5)
+        elif (destination, origin) in self.edges.keys():
+            orientation = (destination, origin)
+
+        if orientation:
+            if how == "add":
+                self.edges[orientation]['cars_occupied'].append(car_index)
+                print(f"Added {car_index} to {orientation}")
+            elif how == "remove":
+                self.edges[orientation]['cars_occupied'].remove(car_index)
+                print(f"Removing {car_index} to {orientation}")
+            else: raise Exception("Invalid 'how' value, must be 'add' or 'remove'")
+        else:
+            raise KeyError(f"Cannot find the edge {(origin, destination)} or {(destination,origin)}")
     def __draw_intersection__(self, x, y, index=None, offset=5, color="blue"):
 
         """
@@ -212,6 +244,7 @@ class Car:
         print(f"Car {self.index} from origin: {self.origin_node} paths: {paths}")
         self.node_paths = iter(paths[1:]) #ommitting first index, since it is already the origin
         self.next_destination_node = next(self.node_paths)
+        tm.manage_car_from_edge(self.index, self.origin_node, self.next_destination_node, how="add")
 
     def spawn(self, origin, next_immediate_destination, final_destination):
         p1 = tm.intersection_nodes[origin]
@@ -254,11 +287,16 @@ class Car:
                 __move()
         else:
             try:
+                tm.manage_car_from_edge(self.index, self.origin_node, self.next_destination_node, how="remove")
+
                 print(f"Car {self.index} now heading to {self.next_destination_node} from {self.origin_node}")
                 self.origin_node = self.next_destination_node
                 self.next_destination_node = next(self.node_paths)
+
+                tm.manage_car_from_edge(self.index, self.origin_node, self.next_destination_node, how="add")
+
             except StopIteration:
-                print(self.next_destination_node)
+                print(f"StopIteration {self.next_destination_node}")
                 self.arrived = True
                 print(f"Car {self.index} has arrived to destination")
             

--- a/main.py
+++ b/main.py
@@ -52,9 +52,12 @@ class Car:
         self.pos_y = y
         self.car = canvas.create_oval(x0, y0, x1, y1, fill="yellow")
 
-    def get_coords(self):
+    def get_coords(self, xy_only=True):
         x0, y0, x1, y1 = canvas.coords(self.car)
-        return x0 + self.car_radius, y0 + self.car_radius, x1 - self.car_radius, y1 - self.car_radius
+        if xy_only:
+            return x0, y0
+        else:
+            return x0 + self.car_radius, y0 + self.car_radius, x1 - self.car_radius, y1 - self.car_radius
     
     def _move_to(self, x, y):
         x0 = x - self.car_radius
@@ -111,9 +114,14 @@ class Car:
 
             # Get the cars that are in the same edge as the current car
             self.cars_in_the_same_edge = tm.get_cars_in_edge(self.origin_node, self.next_destination_node)
-            distance_to_other_cars = [adjacent_car.get_coords() for index, adjacent_car in self.cars_in_the_same_edge.items()]
-            # print(distance_to_other_cars)
-            #what does canvas coords return
+
+            #exclude the car in the dictionary since we don't need to be checking its own position
+            self.cars_in_the_same_edge = {k:v for k,v in self.cars_in_the_same_edge.items() if k != self.index}
+            # print(f"{self.cars_in_the_same_edge.keys()} called by {self.index}")
+
+            #get distance of other
+            distance_to_other_cars = [math.dist(adjacent_car.get_coords(), self.get_coords()) for index, adjacent_car in self.cars_in_the_same_edge.items()]
+            print(distance_to_other_cars)
 
             #WARN: Starting to get performance issues
 

--- a/main.py
+++ b/main.py
@@ -109,7 +109,10 @@ class Car:
 
         def __move():
             """
-             Move the agent to the next position based on the speed and distance. This is called by the move ()
+             Move the agent to the next position based on the speed and distance.
+
+            #WARN: Starting to get performance issues
+
             """
 
             # Get the cars that are in the same edge as the current car
@@ -119,11 +122,10 @@ class Car:
             self.cars_in_the_same_edge = {k:v for k,v in self.cars_in_the_same_edge.items() if k != self.index}
             # print(f"{self.cars_in_the_same_edge.keys()} called by {self.index}")
 
-            #get distance of other
+            #get distance of other cars
             distance_to_other_cars = [math.dist(adjacent_car.get_coords(), self.get_coords()) for index, adjacent_car in self.cars_in_the_same_edge.items()]
             print(distance_to_other_cars)
 
-            #WARN: Starting to get performance issues
 
             step = min(self.speed, distance)
             self.pos_x += (dx / distance) * step

--- a/main.py
+++ b/main.py
@@ -114,9 +114,6 @@ class Car:
             """
 
             # Get the cars that are in the same edge as the current car. but also remove self in that list to prevent measuring its own position
-            # if self.index == 2:
-            #     print("OH NO")
-
             cars_in_the_same_edge = tm.get_cars_in_edge(self.origin_node, self.next_destination_node)
             current_car_index = cars_in_the_same_edge.index(self)
 
@@ -125,9 +122,7 @@ class Car:
             #get distance of other cars, variable name originally distance_to_other_cars
             distance_to_front_cars = [math.dist(adjacent_car.get_coords(), self.get_coords()) for adjacent_car in cars_in_the_same_edge] if cars_in_the_same_edge else None
 
-            if distance_to_front_cars:
-                nearest_car = min(distance_to_front_cars)
-            
+            #then get nearest car by performing min() func to the distance of other front cars
             nearest_car = min(distance_to_front_cars) if distance_to_front_cars else None
 
             if not nearest_car or nearest_car > self.car_collision_observe_distance:

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ class TrafficManager():
 
     def change_light_state(self, intersection_node, neighboring_node, color_state=None, timer=None):
         #change color state
+        # Set color state to red if color is red or red
         if color_state is None:
             if self.intersection_states[intersection_node][neighboring_node]["color"] == "red":
                 color_state = "green"
@@ -50,16 +51,34 @@ class TrafficManager():
         self.intersection_states[intersection_node][neighboring_node]["timer"] = self.default_intersection_time if timer is None else timer
 
     def get_intersection_light_state(self, intersection_node, neighboring_node):
-        # print(f"intersection_node: {intersection_node} origin_node: {neighboring_node}")
+        """
+         Get the light state of a neighboring node. This is used to determine whether or not a node is intersecting another node.
+         
+         @param intersection_node - The node that is intersecting.
+         @param neighboring_node - The node that is a neighboring node.
+         
+         @return The light state of the neighboring node in the color
+        """
         return self.intersection_states[intersection_node][neighboring_node]["color"]
     
     def destination_has_intersection(self, intersection_node):
+        """
+         Checks if the destination node has an intersection. This is used to determine if there is a point in the destination to be intersected with the source
+         
+         @param intersection_node - The node that we are interested in
+         
+         @return True if the destination node has an intersection False if
+        """
+        # Returns true if the intersection node is in the intersection states
         if intersection_node in self.intersection_states:
             return True
         else:
             return False
 
     def __build_network__(self):
+        """
+         Builds the network
+        """
         self.intersection_nodes = {
             #ENTRY NODES
             'E1': (200, 50), #just above Node 2
@@ -86,13 +105,16 @@ class TrafficManager():
 
         self.edges = {i: {'cars_occupied': [], 'has_accident': False, 'road_speed': 50, 'one_way': False} for i in self.edge_list}
 
+        # Add a node to the graph.
         for index, pos in self.intersection_nodes.items():
+            # Add index to the list of entries in the entry_nodes list.
             if type(index) == str and "E" in index:
                 self.entry_nodes.append(index)
             self.G.add_node(index, pos=pos)
 
+        # Add edges to the graph.
         for edges in self.edge_list:
-            # if type(index) == str and "E" in [edges[0], edges[1]]:
+            # Add edges to the entry edges list
             if any(isinstance(edge, str) for edge in edges) and any("E" in edge for edge in edges):
                 #for now we will assume that the entry edge is at the first element
                 self.entry_edges.append(edges)
@@ -100,12 +122,14 @@ class TrafficManager():
             self.G.add_edge(edges[0], edges[1])
             self.G.add_edge(edges[1], edges[0])
 
-        #loop all nodes and check which nodes have more than 2 edges, and apply intersection states for each edge
+        # Loop all nodes and check which nodes have more than 2 edges, and apply intersection states for each edge
         for n in self.G:
             # print(f"G Degree of {n}: {self.G.degree[n]}")
+            # Apply intersection light states between nodes
             if self.G.degree[n] > 2: #check if node has more than 2 neighbors then apply intersection light states
                 neighbor_nodes = list(self.G.neighbors(n))
                 self.intersection_states[n] = {}
+                # This function is used to generate a dictionary of light states between nodes and neighbors
                 for index, neighbor in enumerate(neighbor_nodes): #needed to enumerate so I can use module to alternate values
                     color_state = "green"
                     if index % 2 == 0: #alternate light states between nodes
@@ -115,30 +139,13 @@ class TrafficManager():
                         "timer": self.default_intersection_time
                     }
 
-        """
-        Draw the nodes as intersection junctions
-        """
+        # Draw the intersection of all nodes in the intersection_nodes.
         for index, pos in self.intersection_nodes.items():
             self.__draw_intersection__(*pos, index=index)
 
-        """
-        Draw a line using the edge information
-        """
+        # Draw all lines from the edges of the graph.
         for edge in self.edges:
             self.__draw_line_from_edge__(*edge)
-            
-    # def add_car_to_edge(self, car_index, origin, destination):
-    #     #check the orientation of origin,destination in the tuple
-    #     orientation1 = (origin, destination)
-    #     orientation2 = (destination, origin)
-    #     if orientation1 in self.edges.keys() or orientation2 in self.edges.keys():
-    #         self.edges[orientation1]['cars_occupied'].append(car_index)
-
-    # def remove_car_from_edge(self, car_index, origin, destination):
-    #     orientation1 = (origin, destination)
-    #     orientation2 = (destination, origin)
-    #     if orientation1 in self.edges.keys() or orientation2 in self.edges.keys():
-    #         self.edges[orientation1]['cars_occupied'].remove(car_index)
 
     def manage_car_from_edge(self, car_index: int, origin: int, destination: int, how: str):
         orientation = None
@@ -175,8 +182,15 @@ class TrafficManager():
 
     def __draw_intersection__(self, x, y, index=None, offset=5, color="blue"):
         """
-        Now drawing the road network using the graph
+         Draw the road network using the graph. This is the function that is called by __draw_network
+         
+         @param x - X coordinate of the top left corner of the graph
+         @param y - Y coordinate of the top left corner of the graph
+         @param index - Index of the node to draw. If None the node is drawn at the edge
+         @param offset - Offset to draw the node at
+         @param color - Color of the node
         """
+
         x0 = x - self.intersection_radius
         y0 = y - self.intersection_radius
         x1 = x + self.intersection_radius
@@ -259,6 +273,13 @@ class Car:
         tm.manage_car_from_edge(self.index, self.origin_node, self.next_destination_node, how="add")
 
     def spawn(self, origin, next_immediate_destination, final_destination):
+        """
+         Spawn car at the origin node (usually an entry node). This is used to generate an edge from origin to next_immediate_destination
+         
+         @param origin - origin of car to spawn
+         @param next_immediate_destination - next destination of car to spawn
+         @param final_destination - final destination of car to spawn ( can be same
+        """
         p1 = tm.intersection_nodes[origin]
         # p2 = tm.intersection_nodes[next_immediate_destination]
 
@@ -272,7 +293,9 @@ class Car:
         self.is_spawned = True
 
     def travel(self):
-        #get the paths
+        """
+         Move the car to the next destination based on the speed and distance. This is called every frame
+        """
         des_x, des_y = tm.intersection_nodes[self.next_destination_node]
 
         dx = des_x - self.pos_x #use euclidean distance to judge the movement of the car even in an angle
@@ -280,18 +303,22 @@ class Car:
         distance = math.sqrt(dx ** 2 + dy ** 2)
 
         def __move():
+            """
+             Move the agent to the next position based on the speed and distance. This is called by the move ()
+            """
             step = min(self.speed, distance)
             self.pos_x += (dx / distance) * step
             self.pos_y += (dy / distance) * step
             self._move_to(self.pos_x, self.pos_y)
 
         # Get the cars that are in the same edge as the current car
-
+        # This method is called when the distance is below the light observation distance threshold.
         if distance > self.light_observation_distance:
             # cars_in_same_edge = tm.get_cars_in_edge(self.origin_node, self.next_destination_node)
             __move()
 
         elif distance > 0:
+            # Move the destination to the next destination node if the intersection is green
             if tm.destination_has_intersection(self.next_destination_node):
                 if tm.get_intersection_light_state(self.next_destination_node, self.origin_node) == "red":
                     #do not move if intersection is red

--- a/main.py
+++ b/main.py
@@ -110,30 +110,22 @@ class Car:
         def __move():
             """
              Move the agent to the next position based on the speed and distance.
-
             #WARN: Starting to get performance issues
-
             """
 
             # Get the cars that are in the same edge as the current car. but also remove self in that list to prevent measuring its own position
-            cars_in_the_same_edge = tm.get_cars_in_edge(self.origin_node, self.next_destination_node)
+            # if self.index == 2:
+            #     print("OH NO")
 
+            cars_in_the_same_edge = tm.get_cars_in_edge(self.origin_node, self.next_destination_node)
             current_car_index = cars_in_the_same_edge.index(self)
 
-            print(current_car_index)
-
-            # Calculate the number of cars to remove from the end. This will assume that cars ahead of the entry order will only be observed
-            items_to_remove = len(cars_in_the_same_edge) - current_car_index - 1
-            cars_in_the_same_edge = cars_in_the_same_edge[:-items_to_remove]
-
-            if cars_in_the_same_edge:
-                cars_in_the_same_edge.remove(self)
+            cars_in_the_same_edge = cars_in_the_same_edge[:current_car_index]
 
             #get distance of other cars, variable name originally distance_to_other_cars
             distance_to_front_cars = [math.dist(adjacent_car.get_coords(), self.get_coords()) for adjacent_car in cars_in_the_same_edge] if cars_in_the_same_edge else None
 
             if distance_to_front_cars:
-                print(min(distance_to_front_cars))
                 nearest_car = min(distance_to_front_cars)
             
             nearest_car = min(distance_to_front_cars) if distance_to_front_cars else None


### PR DESCRIPTION
For queueing, I had to implement an ordered list where each car is appended into the queue by their entry order into a certain edge, this will be easier to maintain later as we don't each each of the car to observe the positions of other cars and we only want each car to focus on the one in front of them.

For the fix intersection adjacent light color state issue, the issue was fixed from the modulo operation when it alternates the color states between lighting. This might be a temporary solution as this still haven't been tested on other types of intersection networks. 

Closes #9 and closes #11